### PR TITLE
feat: handle auth methods in mail configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>0.18</version>
                 <configuration>
                     <nodeVersion>12.13.0</nodeVersion>
                     <prettierJavaVersion>1.6.1</prettierJavaVersion>

--- a/src/main/java/io/gravitee/notifier/email/configuration/EmailNotifierConfiguration.java
+++ b/src/main/java/io/gravitee/notifier/email/configuration/EmailNotifierConfiguration.java
@@ -17,6 +17,7 @@ package io.gravitee.notifier.email.configuration;
 
 import io.gravitee.notifier.api.NotifierConfiguration;
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -39,6 +40,11 @@ public class EmailNotifierConfiguration implements NotifierConfiguration, Serial
     private boolean sslTrustAll;
     private String sslKeyStore;
     private String sslKeyStorePassword;
+
+    /**
+     * Possible values at io.vertx.ext.mail.impl.sasl.AuthOperationFactory#ALGORITHMS
+     * */
+    private Set<String> authMethods;
 
     public String getHost() {
         return host;
@@ -130,5 +136,13 @@ public class EmailNotifierConfiguration implements NotifierConfiguration, Serial
 
     public void setSslKeyStorePassword(String sslKeyStorePassword) {
         this.sslKeyStorePassword = sslKeyStorePassword;
+    }
+
+    public Set<String> getAuthMethods() {
+        return authMethods;
+    }
+
+    public void setAuthMethods(Set<String> authMethods) {
+        this.authMethods = authMethods;
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,48 +1,76 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:notifier:email:configuration:EmailNotifierConfiguration",
-  "properties" : {
-    "host" : {
+  "type": "object",
+  "id": "urn:jsonschema:io:gravitee:notifier:email:configuration:EmailNotifierConfiguration",
+  "properties": {
+    "host": {
       "title": "Host",
       "description": "SMTP Host",
-      "type" : "string"
+      "type": "string"
     },
-    "port" : {
+    "port": {
       "title": "Port",
       "description": "SMTP Port",
-      "type" : "integer"
+      "type": "integer"
     },
-    "username" : {
+    "username": {
       "title": "Username",
       "description": "SMTP Username",
-      "type" : "string"
+      "type": "string"
     },
-    "password" : {
+    "password": {
       "title": "Password",
       "description": "SMTP Password",
-      "type" : "string",
+      "type": "string",
       "widget": "password",
-      "sensitive" : true
+      "sensitive": true
     },
-    "from" : {
+    "authMethods": {
+      "title": "Allowed authentication methods",
+      "description": "Restricts authentication methods, no choice means all are authorized",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "XOAUTH2",
+          "NTLM",
+          "DIGEST-MD5",
+          "CRAM-SHA256",
+          "CRAM-SHA1",
+          "CRAM-MD5",
+          "LOGIN",
+          "PLAIN"
+        ]
+      },
+      "default": [
+        "XOAUTH2",
+        "NTLM",
+        "DIGEST-MD5",
+        "CRAM-SHA256",
+        "CRAM-SHA1",
+        "CRAM-MD5",
+        "LOGIN",
+        "PLAIN"
+      ]
+    },
+    "from": {
       "title": "From",
       "description": "Email address used as 'from' when sending email",
-      "type" : "string"
+      "type": "string"
     },
-    "to" : {
+    "to": {
       "title": "Recipients",
       "description": "The recipients of the email",
-      "type" : "string"
+      "type": "string"
     },
-    "subject" : {
+    "subject": {
       "title": "Subject",
       "description": "The subject of the email",
-      "type" : "string"
+      "type": "string"
     },
-    "body" : {
+    "body": {
       "title": "Body",
       "description": "The email payload",
-      "type" : "string",
+      "type": "string",
       "x-schema-form": {
         "type": "codemirror",
         "codemirrorOptions": {
@@ -57,26 +85,26 @@
         }
       }
     },
-    "startTLSEnabled" : {
+    "startTLSEnabled": {
       "title": "Start TLS enabled",
       "description": "SMTP server TLS activation",
-      "type" : "boolean"
+      "type": "boolean"
     },
-    "sslTrustAll" : {
+    "sslTrustAll": {
       "title": "SSL trust all",
       "description": "Email address used as 'from' when sending email",
-      "type" : "boolean"
+      "type": "boolean"
     },
-    "sslKeyStore" : {
+    "sslKeyStore": {
       "title": "SSL key store",
       "description": "Keystore path for SMTP exposition through SMTPS protocol",
-      "type" : "string"
+      "type": "string"
     },
-    "sslKeyStorePassword" : {
+    "sslKeyStorePassword": {
       "title": "SSL key store password",
       "description": "Keystore password for SMTP exposition through SMTPS protocol",
-      "type" : "string",
-      "sensitive" : true
+      "type": "string",
+      "sensitive": true
     }
   },
   "required": [


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8655

**Description**

This PR brings an AuthMethod choices to be used by the client to send an email 

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.0-AE-40-email-notifier-auth-methods-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-email/1.5.0-AE-40-email-notifier-auth-methods-SNAPSHOT/gravitee-notifier-email-1.5.0-AE-40-email-notifier-auth-methods-SNAPSHOT.zip)
  <!-- Version placeholder end -->
