### PR TITLE
fix: target parent 24 to not compile notifier in Java 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@5.5.0
+    gravitee: gravitee-io/gravitee@6.0.0
 
 parameters:
     jobCacheVersion:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [4.0.0-alpha.1](https://github.com/gravitee-io/gravitee-notifier-email/compare/3.0.0...4.0.0-alpha.1) (2026-04-01)
+
+
+### Features
+
+* bump orb version ([7df1ec8](https://github.com/gravitee-io/gravitee-notifier-email/commit/7df1ec83dbb78916a0c1f56fbc7e3d5ed96a4b7e))
+* bumped AM version to 4.12.0-alpha.1 ([83ad764](https://github.com/gravitee-io/gravitee-notifier-email/commit/83ad7645bdb1cb2661784f3684f7c5710418b303))
+* vertx 5 upgrade, BREAKING CHANGES ([da034e7](https://github.com/gravitee-io/gravitee-notifier-email/commit/da034e7b68471c2eb25a6e5ca5a60fd58a6e0b83))
+
+
+### BREAKING CHANGES
+
+* JDK 25
+
 # [3.0.0](https://github.com/gravitee-io/gravitee-notifier-email/compare/2.0.0...3.0.0) (2026-03-16)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.notifier</groupId>
     <artifactId>gravitee-notifier-email</artifactId>
-    <version>3.0.0</version>
+    <version>4.0.0-alpha.1</version>
 
     <name>Gravitee.io APIM - Notifier - Email</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <name>Gravitee.io APIM - Notifier - Email</name>
 
     <properties>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
-        <gravitee-common.version>4.9.0</gravitee-common.version>
+        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
+        <gravitee-common.version>5.0.0-beta.1</gravitee-common.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
-        <gravitee-node.version>8.0.1</gravitee-node.version>
+        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
 
         <freemarker.version>2.3.34</freemarker.version>
         <greenmail-junit5.version>2.1.8</greenmail-junit5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     <name>Gravitee.io APIM - Notifier - Email</name>
 
     <properties>
-        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
-        <gravitee-common.version>5.0.0-beta.1</gravitee-common.version>
+        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
-        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
 
         <freemarker.version>2.3.34</freemarker.version>
         <greenmail-junit5.version>2.1.8</greenmail-junit5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>24.0.0</version>
+        <version>25.0.0-alpha.1</version>
     </parent>
 
     <groupId>io.gravitee.notifier</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>25.0.0-alpha.1</version>
+        <version>24.0.2</version>
     </parent>
 
     <groupId>io.gravitee.notifier</groupId>
@@ -34,10 +34,10 @@
     <name>Gravitee.io APIM - Notifier - Email</name>
 
     <properties>
-        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
-        <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
+        <gravitee-bom.version>9.0.0</gravitee-bom.version>
+        <gravitee-common.version>5.0.0</gravitee-common.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
-        <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
+        <gravitee-node.version>9.0.0</gravitee-node.version>
 
         <freemarker.version>2.3.34</freemarker.version>
         <greenmail-junit5.version>2.1.8</greenmail-junit5.version>

--- a/src/main/java/io/gravitee/notifier/email/EmailNotifier.java
+++ b/src/main/java/io/gravitee/notifier/email/EmailNotifier.java
@@ -80,18 +80,16 @@ public class EmailNotifier extends AbstractConfigurableNotifier<EmailNotifierCon
         try {
             final MailMessage mailMessage = prepareMailMessage(parameters);
             final MailConfig mailConfig = prepareMailConfig();
-            createShared(Vertx.currentContext().owner(), mailConfig, valueOf(mailConfig.getHostname().hashCode())).sendMail(
-                mailMessage,
-                e -> {
-                    if (e.succeeded()) {
-                        logger.debug("Email {} has been send successfully!", e.result().getMessageID());
-                        future.complete(null);
-                    } else {
-                        logger.error("An error occurs while sending email", e.cause());
-                        future.completeExceptionally(e.cause());
-                    }
-                }
-            );
+            createShared(Vertx.currentContext().owner(), mailConfig, valueOf(mailConfig.getHostname().hashCode()))
+                .sendMail(mailMessage)
+                .onSuccess(result -> {
+                    logger.debug("Email {} has been send successfully!", result.getMessageID());
+                    future.complete(null);
+                })
+                .onFailure(cause -> {
+                    logger.error("An error occurs while sending email", cause);
+                    future.completeExceptionally(cause);
+                });
         } catch (final Exception ex) {
             logger.error("Error while sending email notification", ex);
             future.completeExceptionally(ex);
@@ -141,10 +139,11 @@ public class EmailNotifier extends AbstractConfigurableNotifier<EmailNotifierCon
         }
 
         if (nonNull(configuration.getSslKeyStore())) {
-            mailConfig.setKeyStore(configuration.getSslKeyStore());
-        }
-        if (nonNull(configuration.getSslKeyStorePassword())) {
-            mailConfig.setKeyStorePassword(configuration.getSslKeyStorePassword());
+            var jksOptions = new io.vertx.core.net.JksOptions().setPath(configuration.getSslKeyStore());
+            if (nonNull(configuration.getSslKeyStorePassword())) {
+                jksOptions.setPassword(configuration.getSslKeyStorePassword());
+            }
+            mailConfig.setKeyCertOptions(jksOptions);
         }
 
         if (configuration.isStartTLSEnabled()) {


### PR DESCRIPTION
 bump the dependency to use final release
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-prepare-4-12-release-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-email/4.0.0-prepare-4-12-release-SNAPSHOT/gravitee-notifier-email-4.0.0-prepare-4-12-release-SNAPSHOT.zip)
  <!-- Version placeholder end -->
