### PR TITLE
fix: closed mailClient after mail has been sent

### DIFF
--- a/src/main/java/io/gravitee/notifier/email/EmailNotifier.java
+++ b/src/main/java/io/gravitee/notifier/email/EmailNotifier.java
@@ -16,7 +16,6 @@
 package io.gravitee.notifier.email;
 
 import static io.vertx.core.buffer.Buffer.buffer;
-import static io.vertx.ext.mail.MailClient.createShared;
 import static java.lang.String.valueOf;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.Objects.nonNull;
@@ -80,14 +79,17 @@ public class EmailNotifier extends AbstractConfigurableNotifier<EmailNotifierCon
         try {
             final MailMessage mailMessage = prepareMailMessage(parameters);
             final MailConfig mailConfig = prepareMailConfig();
-            createShared(Vertx.currentContext().owner(), mailConfig, valueOf(mailConfig.getHostname().hashCode()))
+            final MailClient mailClient = MailClient.create(Vertx.currentContext().owner(), mailConfig);
+            mailClient
                 .sendMail(mailMessage)
                 .onSuccess(result -> {
                     logger.debug("Email {} has been send successfully!", result.getMessageID());
+                    mailClient.close();
                     future.complete(null);
                 })
                 .onFailure(cause -> {
                     logger.error("An error occurs while sending email", cause);
+                    mailClient.close();
                     future.completeExceptionally(cause);
                 });
         } catch (final Exception ex) {


### PR DESCRIPTION
this change avoid error logs triggered asynchronously by vertx

fix AM-7187
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-am-7187-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/notifier/gravitee-notifier-email/4.0.1-am-7187-SNAPSHOT/gravitee-notifier-email-4.0.1-am-7187-SNAPSHOT.zip)
  <!-- Version placeholder end -->
